### PR TITLE
Added MVP Networking Tests

### DIFF
--- a/nephoria/testcases/cloudformation/mvp_templates/s3/cfn-s3-bucket-test-min.json
+++ b/nephoria/testcases/cloudformation/mvp_templates/s3/cfn-s3-bucket-test-min.json
@@ -7,7 +7,7 @@
         "Bucket" : {
             "Type" : "AWS::S3::Bucket",
             "Properties" : {
-                "Tags" : [ {"Key" : "Application", "Value" : "bucket-tagging-test" } ]
+                "Tags" : [ {"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} } ]
             }
         }
     },

--- a/nephoria/testcases/cloudformation/mvp_templates/vpc/cfn-networking-test-min.json
+++ b/nephoria/testcases/cloudformation/mvp_templates/vpc/cfn-networking-test-min.json
@@ -1,0 +1,239 @@
+{
+
+    "AWSTemplateFormatVersion" : "2010-09-09",
+
+    "Description" : "Networking Test => MVP for following resources: AWS::EC2::VPC, AWS::EC2::Subnet, AWS::EC2::InternetGateway, AWS::EC2::VPCGatewayAttachment, AWS::EC2::RouteTable, AWS::EC2::Route, AWS::EC2::SubnetRouteTableAssociation, AWS::EC2::NetworkAcl, AWS::EC2::NetworkAclEntry, and AWS::EC2::SubnetNetworkAclAssociation",
+
+    "Resources" : {
+        "VPC": {
+            "Type": "AWS::EC2::VPC",
+            "Properties" : {
+                "CidrBlock" : "10.0.0.0/16",
+                "Tags" : [ {"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"}} ]
+            }
+        },
+
+        "Subnet": {
+            "Type" : "AWS::EC2::Subnet",
+            "Properties" : {
+                "VpcId" : { "Ref" : "VPC" },
+                "CidrBlock" : "10.0.0.0/24",
+                "Tags" : [ {"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} } ]
+            }
+        },
+
+        "InternetGateway" : {
+            "Type" : "AWS::EC2::InternetGateway",
+            "Properties" : {
+                "Tags" : [ {"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} } ]
+            }
+        },
+
+        "VPCGatewayAttachment" : {
+            "Type" : "AWS::EC2::VPCGatewayAttachment",
+            "Properties" : {
+                "VpcId" : { "Ref" : "VPC" },
+                "InternetGatewayId" : { "Ref" : "InternetGateway" }
+            }
+        },
+
+        "RouteTable": {
+            "Type" : "AWS::EC2::RouteTable",
+            "Properties" : {
+                "VpcId" : { "Ref" : "VPC" },
+                "Tags" : [ {"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} } ]
+            }
+        },
+
+        "Route" : {
+            "Type" : "AWS::EC2::Route",
+            "DependsOn" : "VPCGatewayAttachment",
+            "Properties" : {
+                "RouteTableId" : { "Ref" : "RouteTable" },
+                "DestinationCidrBlock" : "0.0.0.0/0",
+                "GatewayId" : { "Ref" : "InternetGateway" }
+            }
+        },
+
+        "SubnetRouteTableAssocaiation" : {
+            "Type" : "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties" : {
+                "SubnetId" : { "Ref" : "Subnet" },
+                "RouteTableId" : { "Ref" : "RouteTable" }
+            }
+        },
+
+        "NetworkAcl" : {
+            "Type" : "AWS::EC2::NetworkAcl",
+            "Properties" : {
+                "VpcId" : {"Ref" : "VPC"},
+                "Tags" : [ {"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"} } ]
+            }
+        },
+
+        "InboundSSHNetworkAclEntry" : {
+            "Type" : "AWS::EC2::NetworkAclEntry",
+            "Properties" : {
+                "NetworkAclId" : {"Ref" : "NetworkAcl"},
+                "RuleNumber" : "101",
+                "Protocol" : "6",
+                "RuleAction" : "allow",
+                "Egress" : "false",
+                "CidrBlock" : "0.0.0.0/0",
+                "PortRange" : {"From" : "22", "To" : "22"}
+            }
+        },
+
+        "InboundResponsePortsNetworkAclEntry" : {
+            "Type" : "AWS::EC2::NetworkAclEntry",
+            "Properties" : {
+                "NetworkAclId" : {"Ref" : "NetworkAcl"},
+                "RuleNumber" : "102",
+                "Protocol" : "6",
+                "RuleAction" : "allow",
+                "Egress" : "false",
+                "CidrBlock" : "0.0.0.0/0",
+                "PortRange" : {"From" : "1024", "To" : "65535"}
+            }
+        },
+
+        "OutBoundHTTPNetworkAclEntry" : {
+            "Type" : "AWS::EC2::NetworkAclEntry",
+            "Properties" : {
+                "NetworkAclId" : {"Ref" : "NetworkAcl"},
+                "RuleNumber" : "100",
+                "Protocol" : "6",
+                "RuleAction" : "allow",
+                "Egress" : "true",
+                "CidrBlock" : "0.0.0.0/0",
+                "PortRange" : {"From" : "80", "To" : "80"}
+            }
+        },
+
+        "OutBoundHTTPSNetworkAclEntry" : {
+            "Type" : "AWS::EC2::NetworkAclEntry",
+            "Properties" : {
+                "NetworkAclId" : {"Ref" : "NetworkAcl"},
+                "RuleNumber" : "101",
+                "Protocol" : "6",
+                "RuleAction" : "allow",
+                "Egress" : "true",
+                "CidrBlock" : "0.0.0.0/0",
+                "PortRange" : {"From" : "443", "To" : "443"}
+            }
+        },
+
+        "OutboundResponsePortsNetworkAclEntry" : {
+            "Type" : "AWS::EC2::NetworkAclEntry",
+            "Properties" : {
+                "NetworkAclId" : {"Ref" : "NetworkAcl"},
+                "RuleNumber" : "102",
+                "Protocol" : "6",
+                "RuleAction" : "allow",
+                "Egress" : "true",
+                "CidrBlock" : "0.0.0.0/0",
+                "PortRange" : {"From" : "1024", "To" : "65535"}
+            }
+        },
+
+        "SubnetNetworkAclAssociation" : {
+            "Type" : "AWS::EC2::SubnetNetworkAclAssociation",
+            "Properties" : {
+                "SubnetId" : { "Ref" : "Subnet" },
+                "NetworkAclId" : { "Ref" : "NetworkAcl" }
+            }
+        }
+    },
+
+    "Outputs" : {
+        "VPCId" : {
+            "Description" : "Resource ID of VPC",
+            "Value" : { "Ref" : "VPC" }
+        },
+
+        "VPCCidrBlock" : {
+            "Description" : "CIDR Block of VPC",
+            "Value" : { "Fn::GetAtt" : [ "VPC", "CidrBlock" ] }
+        },
+
+        "VPCDefaultNetworkAcl" : {
+            "Description" : "Default Network Acl of VPC",
+            "Value" : { "Fn::GetAtt" : [ "VPC", "DefaultNetworkAcl" ] }
+        },
+
+        "VPCDefaultSecurityGroup" : {
+            "Description" : "Default Security Group of VPC",
+            "Value" : { "Fn::GetAtt" : [ "VPC", "DefaultSecurityGroup" ] }
+        },
+
+        "SubnetId" : {
+            "Description" : "Resource ID of Subnet",
+            "Value" : { "Ref" : "Subnet" }
+        },
+
+        "SubnetAvailabilityZone" : {
+            "Description" : "Availability Zone of Subnet",
+            "Value" : { "Fn::GetAtt" : [ "Subnet", "AvailabilityZone" ] } 
+        },
+
+        "InternetGatewayId" : {
+            "Description" : "Resource ID of InternetGateway",
+            "Value" : { "Ref" : "InternetGateway" }
+        },
+
+        "VPCGatewayAttachmentId" : {
+            "Description" : "Resource ID of VPCGatewayAttachment",
+            "Value" : { "Ref" : "VPCGatewayAttachment" }
+        },
+
+        "RouteTableId" : {
+            "Description" : "Resource ID of RouteTable",
+            "Value" : { "Ref" : "RouteTable" }
+        },
+
+        "RouteId" : {
+            "Description" : "Resource ID of Route",
+            "Value" : { "Ref" : "Route" }
+        },
+
+        "SubnetRouteTableAssocaiationId" : {
+            "Description" : "Resource ID of SubnetRouteTableAssocaiation",
+            "Value" : { "Ref" : "SubnetRouteTableAssocaiation" }
+        },
+
+        "NetworkAclId" : {
+            "Description" : "Resource ID of NetworkAcl",
+            "Value" : { "Ref" : "NetworkAcl" }
+        },
+ 
+        "InboundSSHNetworkAclEntryId" : {
+            "Description" : "Resource ID of InboundSSHNetworkAclEntry",
+            "Value" : { "Ref" : "InboundSSHNetworkAclEntry" }
+        },
+
+        "InboundResponsePortsNetworkAclEntryId" : {
+            "Description" : "Resource ID of InboundResponsePortsNetworkAclEntry",
+            "Value" : { "Ref" : "InboundResponsePortsNetworkAclEntry" }
+        },
+
+        "OutBoundHTTPNetworkAclEntryId" : {
+            "Description" : "Resource ID of OutBoundHTTPNetworkAclEntry",
+            "Value" : { "Ref" : "OutBoundHTTPNetworkAclEntry" }
+        },
+
+        "OutBoundHTTPSNetworkAclEntryId" :{
+            "Description" : "Resource ID of OutBoundHTTPSNetworkAclEntry",
+            "Value" : { "Ref" : "OutBoundHTTPSNetworkAclEntry" }
+        },
+
+        "OutboundResponsePortsNetworkAclEntryId" : {
+            "Description" : "Resource ID of OutboundResponsePortsNetworkAclEntry",
+            "Value" : { "Ref" : "OutboundResponsePortsNetworkAclEntry" }
+        },
+
+        "SubnetNetworkAclAssociationId" : {
+            "Description" : "Resource ID of SubnetNetworkAclAssociation",
+            "Value" : { "Ref" : "SubnetNetworkAclAssociation" }
+        }        
+    }
+}


### PR DESCRIPTION
Tests for following resources:

- `AWS::EC2::VPC`
- `AWS::EC2::Subnet`
- `AWS::EC2::InternetGateway`
- `AWS::EC2::VPCGatewayAttachment`
- `AWS::EC2::RouteTable`
- `AWS::EC2::Route`
- `AWS::EC2::SubnetRouteTableAssociation`
- `AWS::EC2::NetworkAcl`
- `AWS::EC2::NetworkAclEntry`
- `AWS::EC2::SubnetNetworkAclAssociation`

In addition, updated tag attribute in cfn-s3-bucket-test-min.json.