### PR TITLE
Cloudformation securitygroup resources

### DIFF
--- a/nephoria/testcases/cloudformation/mvp_templates/ec2/cfn-securitygroup-test-min.json
+++ b/nephoria/testcases/cloudformation/mvp_templates/ec2/cfn-securitygroup-test-min.json
@@ -1,0 +1,52 @@
+{
+
+    "AWSTemplateFormatVersion" : "2010-09-09",
+
+    "Description" : "Security Group Test => MVP for AWS::EC2::SecurityGroup and AWS::EC2::SecurityGroupIngress",
+
+
+    "Resources" : {
+        "SecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+                "Properties": {
+                    "GroupDescription" : "AWS::EC2::SecurityGroup Resource Test Example"
+                 }
+        },
+
+        "SecurityGroupIngress22": {
+            "Type": "AWS::EC2::SecurityGroupIngress",
+                "Properties": {
+                            "IpProtocol" : "tcp",
+                            "GroupName": { "Ref" : "SecurityGroup" },
+                            "FromPort" : "22",
+                            "ToPort" : "22",
+                            "SourceSecurityGroupName" : { "Ref" : "SecurityGroup" }
+                }
+        },
+
+        "SecurityGroupIngress443": {
+            "Type": "AWS::EC2::SecurityGroupIngress",
+                "Properties": {
+                            "IpProtocol" : "tcp",
+                            "GroupName": { "Ref" : "SecurityGroup" },
+                            "FromPort" : "22",
+                            "ToPort" : "22",
+                            "CidrIp": "0.0.0.0/0"
+                }
+        }
+
+    },
+
+    "Outputs" : {
+        "SecurityGroupRefId" : {
+            "Description" : "Resource ID of SecurityGroup Resource",
+            "Value" : { "Ref" : "SecurityGroup" }
+        },
+
+        "SecurityGroupId" : {
+            "Description" : "Group ID of SecurityGroup Resource",
+            "Value" : { "Fn::GetAtt" : [ "SecurityGroup", "GroupId" ] }
+       }
+    }
+
+}

--- a/nephoria/testcases/cloudformation/mvp_templates/ec2/cfn-securitygroup-test-min.json
+++ b/nephoria/testcases/cloudformation/mvp_templates/ec2/cfn-securitygroup-test-min.json
@@ -8,31 +8,32 @@
     "Resources" : {
         "SecurityGroup": {
             "Type": "AWS::EC2::SecurityGroup",
-                "Properties": {
-                    "GroupDescription" : "AWS::EC2::SecurityGroup Resource Test Example"
-                 }
+            "Tags": [ {"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"}} ],
+            "Properties": {
+                "GroupDescription" : "AWS::EC2::SecurityGroup Resource Test Example"
+            }
         },
 
         "SecurityGroupIngress22": {
             "Type": "AWS::EC2::SecurityGroupIngress",
-                "Properties": {
-                            "IpProtocol" : "tcp",
-                            "GroupName": { "Ref" : "SecurityGroup" },
-                            "FromPort" : "22",
-                            "ToPort" : "22",
-                            "SourceSecurityGroupName" : { "Ref" : "SecurityGroup" }
-                }
+            "Properties": {
+                "IpProtocol" : "tcp",
+                "GroupName": { "Ref" : "SecurityGroup" },
+                "FromPort" : "22",
+                "ToPort" : "22",
+                "SourceSecurityGroupName" : { "Ref" : "SecurityGroup" }
+            }
         },
 
         "SecurityGroupIngress443": {
             "Type": "AWS::EC2::SecurityGroupIngress",
-                "Properties": {
-                            "IpProtocol" : "tcp",
-                            "GroupName": { "Ref" : "SecurityGroup" },
-                            "FromPort" : "22",
-                            "ToPort" : "22",
-                            "CidrIp": "0.0.0.0/0"
-                }
+            "Properties": {
+                "IpProtocol" : "tcp",
+                "GroupName": { "Ref" : "SecurityGroup" },
+                "FromPort" : "22",
+                "ToPort" : "22",
+                "CidrIp": "0.0.0.0/0"
+            }
         }
 
     },

--- a/nephoria/testcases/cloudformation/mvp_templates/vpc/cfn-securitygroup-test-min.json
+++ b/nephoria/testcases/cloudformation/mvp_templates/vpc/cfn-securitygroup-test-min.json
@@ -1,0 +1,83 @@
+{
+
+    "AWSTemplateFormatVersion" : "2010-09-09",
+
+    "Description" : "Security Group Test => MVP for AWS::EC2::SecurityGroup, AWS::EC2::SecurityGroupIngress, and AWS::EC2::SecurityGroupEgress",
+
+
+    "Resources" : {
+        "VPC": {
+            "Type": "AWS::EC2::VPC",
+            "Properties": {
+                "CidrBlock": "10.0.0.0/16",
+                "InstanceTenancy": "default"
+            }
+        },
+
+        "SecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Properties": {
+                "GroupDescription" : "AWS::EC2::SecurityGroup Resource Test Example in VPC",
+                "VpcId": { "Ref" : "VPC" },
+                "Tags": [ {"Key" : "Application", "Value" : { "Ref" : "AWS::StackId"}} ]
+            }
+        },
+
+        "SecurityGroupIngress22": {
+            "Type": "AWS::EC2::SecurityGroupIngress",
+            "Properties": {
+                "IpProtocol" : "tcp",
+                "GroupId": { "Fn::GetAtt": [ "SecurityGroup", "GroupId" ] },
+                "FromPort" : "22",
+                "ToPort" : "22",
+                "SourceSecurityGroupId": { "Fn::GetAtt": [ "SecurityGroup", "GroupId" ] }
+            }
+        },
+
+        "SecurityGroupIngress443": {
+            "Type": "AWS::EC2::SecurityGroupIngress",
+            "Properties": {
+                "IpProtocol" : "tcp",
+                "GroupId": { "Fn::GetAtt": [ "SecurityGroup", "GroupId" ] },
+                "FromPort" : "22",
+                "ToPort" : "22",
+                "CidrIp": "0.0.0.0/0"
+            }
+        },
+
+        "SecurityGroupEgress": {
+            "Type": "AWS::EC2::SecurityGroupEgress",
+            "Properties": {
+                "CidrIp": "0.0.0.0/0",
+                "FromPort": "0",
+                "GroupId": { "Fn::GetAtt": [ "SecurityGroup", "GroupId" ] },
+                "IpProtocol": "-1",
+                "ToPort": "65535"
+            }
+        }
+
+    },
+
+    "Outputs" : {
+        "VPCId" : {
+            "Description" : "Resource ID of VPC",
+            "Value" : { "Ref" : "VPC" }
+        },
+
+        "VPCCidrBlock" : {
+            "Description" : "CIDR Block of VPC",
+            "Value" : { "Fn::GetAtt" : [ "VPC", "CidrBlock" ] }
+        },
+
+        "SecurityGroupRefId" : {
+            "Description" : "Resource ID of SecurityGroup Resource",
+            "Value" : { "Ref" : "SecurityGroup" }
+        },
+
+        "SecurityGroupId" : {
+            "Description" : "Group ID of SecurityGroup Resource",
+            "Value" : { "Fn::GetAtt" : [ "SecurityGroup", "GroupId" ] }
+       }
+    }
+
+}


### PR DESCRIPTION
Added MVP tests for the following resources:

- `AWS::EC2::SecurityGroup` (EC2-Classic and VPC)
- `AWS::EC2::SecurityGroupIngress` (EC2-Classic and VPC)
- `AWS::EC2::SecurityGroupEgress` (VPC)